### PR TITLE
Fix: SSDT-EXT3-LedReset-TP better compatibility

### DIFF
--- a/10-PTSWAK综合扩展补丁/SSDT-EXT3-LedReset-TP.dsl
+++ b/10-PTSWAK综合扩展补丁/SSDT-EXT3-LedReset-TP.dsl
@@ -3,8 +3,8 @@ DefinitionBlock("", "SSDT", 2, "OCLT", "EXT3", 0)
 {
     External(_SI._SST, MethodObj)
     Method (EXT3, 1, NotSerialized)
-    {   
-        If (3 == Arg0)
+    {
+        If ((3 == Arg0) && CondRefOf (\_SI._SST))
         {
             \_SI._SST (1)
         }

--- a/10-PTSWAK综合扩展补丁/SSDT-EXT3-LedReset-TP.md
+++ b/10-PTSWAK综合扩展补丁/SSDT-EXT3-LedReset-TP.md
@@ -4,8 +4,8 @@ DefinitionBlock("", "SSDT", 2, "OCLT", "EXT3", 0)
 {
     External(_SI._SST, MethodObj)
     Method (EXT3, 1, NotSerialized)
-    {   
-        If (3 == Arg0)
+    {
+        If ((3 == Arg0) && CondRefOf (\_SI._SST))
         {
             \_SI._SST (1)
         }


### PR DESCRIPTION
在调用 `\_SI._SST ()` 方法前先检查是否存在对应声明、改善 SSDT 兼容性。