### PR TITLE
Fix: PTSWAK EXT1 better compatibility

### DIFF
--- a/10-PTSWAK综合扩展补丁/SSDT-EXT1-FixShutdown.dsl
+++ b/10-PTSWAK综合扩展补丁/SSDT-EXT1-FixShutdown.dsl
@@ -6,7 +6,7 @@ DefinitionBlock("", "SSDT", 2, "OCLT", "EXT4", 0)
 
     Method (EXT1, 1, NotSerialized)
     {
-        If (5 == Arg0) {
+        If ((5 == Arg0) && CondRefOf (\_SB.PCI0.XHC.PMEE)) {
             \_SB.PCI0.XHC.PMEE = 0
         }
     }

--- a/10-PTSWAK综合扩展补丁/SSDT-EXT1-FixShutdown.md
+++ b/10-PTSWAK综合扩展补丁/SSDT-EXT1-FixShutdown.md
@@ -7,7 +7,7 @@ DefinitionBlock("", "SSDT", 2, "OCLT", "EXT4", 0)
 
     Method (EXT1, 1, NotSerialized)
     {
-        If (5 == Arg0) {
+        If ((5 == Arg0) && CondRefOf (\_SB.PCI0.XHC.PMEE)) {
             \_SB.PCI0.XHC.PMEE = 0
         }
     }


### PR DESCRIPTION
The continuation of #7. `CondRefOf` is added for the case `_SB.PCI0.XHC.PMEE` doesn't exist.